### PR TITLE
Handle invalid addresses better

### DIFF
--- a/lib/ups/api/address_validation/http.ex
+++ b/lib/ups/api/address_validation/http.ex
@@ -87,6 +87,9 @@ defmodule UPS.API.AddressValidation.HTTP do
     }
   end
 
+  defp format_address({"AddressKeyFormat", address}) do
+    format_address(%{"AddressKeyFormat" => address})
+  end
   defp format_address(%{"AddressKeyFormat" => address}) do
     base = %{
       city: address["PoliticalDivision2"],

--- a/test/ups_test.exs
+++ b/test/ups_test.exs
@@ -55,6 +55,22 @@ defmodule UPSTest do
       assert response.message == "Address is valid."
     end
 
+    test "handles bad addresses with suggestions and without exceptions" do
+      address = %{
+        city: "shasts", 
+        country: "US", 
+        line1: "123 main street", 
+        line2: nil,
+        state: "AK", 
+        zip: "01576"
+      }
+
+      {:ok, %{body: response}} = UPS.validate_address(address)
+      refute response.success
+      assert response.suggestions
+      assert response.message == "Address is not complete."
+    end
+
     test "returns suggestions when address is not complete" do
       address = %{
         line1: "11815 NE 1",


### PR DESCRIPTION
Currently, some invalid addresses cause the following exception:

```
** (FunctionClauseError) no function clause matching in UPS.API.AddressValidation.HTTP.format_address/1
    (ups) lib/ups/api/address_validation/http.ex:91: UPS.API.AddressValidation.HTTP.format_address({"AddressKeyFormat", %{"AddressLine" => "123 MAIN ST", "CountryCode" => "US", "PoliticalDivision1" => "MA", "PoliticalDivision2" => "DUDLEY HILL", "PostcodeExtendedLow" => "2209", "PostcodePrimaryLow" => "01570", "Region" => "DUDLEY HILL MA 01570-2209"}})
    (elixir) lib/enum.ex:1233: anonymous fn/3 in Enum.map/2
    (stdlib) lists.erl:1263: :lists.foldl/3
    (elixir) lib/enum.ex:1772: Enum.map/2
    (ups) lib/ups/api/address_validation/http.ex:78: UPS.API.AddressValidation.HTTP.format_response/1
    (httpoison) lib/httpoison/base.ex:471: HTTPoison.Base.response/6
    (ecto) lib/ecto/multi.ex:406: Ecto.Multi.apply_operation/5
    (elixir) lib/enum.ex:1755: Enum."-reduce/3-lists^foldl/2-0-"/3
    (ecto) lib/ecto/multi.ex:396: anonymous fn/5 in Ecto.Multi.apply_operations/5
    (ecto) lib/ecto/adapters/sql.ex:620: anonymous fn/3 in Ecto.Adapters.SQL.do_transaction/3
    (db_connection) lib/db_connection.ex:1275: DBConnection.transaction_run/4
    (db_connection) lib/db_connection.ex:1199: DBConnection.run_begin/3
    (db_connection) lib/db_connection.ex:790: DBConnection.transaction/3
    (ecto) lib/ecto/repo/queryable.ex:21: Ecto.Repo.Queryable.transaction/4
```

This seems to be because when we [map suggestions](https://github.com/infinitered/ups/blob/ea6d3dfe587ebf926f4e85f21804c3b6208242e4/lib/ups/api/address_validation/http.ex#L77), the `format_address` function gets called with a tuple instead of a map.

This adds a test and extra function definition to fix the problem.