### PR TITLE
Return :error tuples instead of {:ok, %{success false}}

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ by adding `ups` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
-  [{:ups, "~> 0.1.0"}]
+  [{:ups, "~> 0.2.0"}]
 end
 ```
 

--- a/lib/ups/api/address_validation.ex
+++ b/lib/ups/api/address_validation.ex
@@ -1,0 +1,9 @@
+defmodule UPS.API.AddressValidation do
+  @moduledoc """
+  Behaviour for address validation implementations.
+  """
+
+  @callback post(map, Keyword.t) ::
+    {:ok, HTTPoison.Response.t} |
+    {:error, HTTPoison.Error.t}
+end

--- a/lib/ups/api/address_validation/http.ex
+++ b/lib/ups/api/address_validation/http.ex
@@ -6,6 +6,8 @@ defmodule UPS.API.AddressValidation.HTTP do
 
   alias UPS.Config
 
+  @behaviour UPS.API.AddressValidation
+
   # HTTPoison Callbacks
   # -------------------
 
@@ -19,7 +21,12 @@ defmodule UPS.API.AddressValidation.HTTP do
   end
 
   def process_response_body(body) do
-    format_response(Poison.decode!(body))
+    with {:ok, json} <- Poison.decode(body) do
+      format_response(json)
+    else
+      {:error, error} ->
+        error
+    end
   end
 
   def process_request_body(body) do

--- a/lib/ups/exceptions/validation_error.ex
+++ b/lib/ups/exceptions/validation_error.ex
@@ -1,0 +1,3 @@
+defmodule UPS.ValidationError do
+  defexception message: nil, raw_body: nil, suggestions: []
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule UPS.Mixfile do
   def project do
     [app: :ups,
      description: "Basic Elixir HTTPoison wrapper around the UPS street level validation API.",
-     version: "0.1.0",
+     version: "0.2.0",
      elixir: "~> 1.4",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,

--- a/test/ups_test.exs
+++ b/test/ups_test.exs
@@ -1,6 +1,5 @@
 defmodule UPSTest do
   use ExUnit.Case
-  # doctest Ups
 
   describe ".validate_address" do
     test "validate address returns successful response when valid address is passed" do
@@ -65,10 +64,9 @@ defmodule UPSTest do
         zip: "01576"
       }
 
-      {:ok, %{body: response}} = UPS.validate_address(address)
-      refute response.success
-      assert response.suggestions
-      assert response.message == "Address is not complete."
+      {:error, %UPS.ValidationError{} = error} = UPS.validate_address(address)
+      assert length(error.suggestions) > 0
+      assert error.message == "Address is not complete."
     end
 
     test "returns suggestions when address is not complete" do
@@ -81,11 +79,10 @@ defmodule UPSTest do
         country: "US"
       }
 
-      {:ok, %{body: response}} = UPS.validate_address(address)
+      {:error, %UPS.ValidationError{} = error} = UPS.validate_address(address)
 
-      refute response.success
-      assert response.suggestions
-      assert response.message == "Address is not complete."
+      assert length(error.suggestions) > 0
+      assert error.message == "Address is not complete."
     end
 
     test "returns raw errors when address is not passed correctly" do
@@ -98,11 +95,10 @@ defmodule UPSTest do
         country: ""
       }
 
-      {:ok, %{body: response}} = UPS.validate_address(address)
+      {:error, %UPS.ValidationError{} = error} = UPS.validate_address(address)
 
-      refute response.success
-      assert response.raw_body["Fault"]
-      assert response.message == "Address is not valid."
+      assert error.raw_body["Fault"]
+      assert error.message == "Address is not valid."
     end
   end
 end


### PR DESCRIPTION
This makes it much more straightforward to pattern match on the results
of `UPS.validate_address/1`